### PR TITLE
chore(repo): bootstrap public root with README, LICENSE, .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,106 @@
+# =============================================================================
+# .gitignore — atomicvulns
+# =============================================================================
+# Keep the tree clean of generated artifacts, per-developer noise, and files
+# that would leak local state or secrets. Grouped by category; stack rationale
+# for each group lives in CLAUDE.md.
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Python — default stack for most atoms (CLAUDE.md §3.1).
+# Bytecode caches, virtual envs, local dotenv files, and tool caches.
+# ---------------------------------------------------------------------------
+
+# Bytecode caches and compiled modules — regenerated on every run.
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Virtual environments — machine-local, must not be tracked.
+venv/
+.venv/
+env/
+ENV/
+
+# Environment files with secrets or local-only config.
+.env
+.env.local
+.env.*.local
+
+# Test, lint, and type-check caches.
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+
+# Packaging artifacts (atoms aren't published as packages, but just in case).
+*.egg
+*.egg-info/
+dist/
+build/
+
+# ---------------------------------------------------------------------------
+# Node.js — only the few atoms where the vuln is JS-idiomatic (CLAUDE.md §3.2):
+# prototype-pollution, deserialization-node. Ignored repo-wide regardless.
+# ---------------------------------------------------------------------------
+
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# ---------------------------------------------------------------------------
+# SQLite — every atom that uses SQLite seeds its local DB on startup.
+# Schema and seed scripts live in the repo; the DB file itself is generated.
+# ---------------------------------------------------------------------------
+
+*.db
+*.db-journal
+*.sqlite
+*.sqlite-journal
+*.sqlite3
+*.sqlite3-journal
+
+# ---------------------------------------------------------------------------
+# Docker — developer-only compose overrides and any local bind-mount volumes.
+# Named volumes live inside Docker's own storage, not on disk here, so only
+# what might actually leak into the working tree is listed.
+# ---------------------------------------------------------------------------
+
+docker-compose.override.yml
+docker-compose.override.yaml
+volumes/
+.docker/
+
+# ---------------------------------------------------------------------------
+# IDE and editor noise — per-developer settings, never committed.
+# ---------------------------------------------------------------------------
+
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS-level junk files dropped into working directories.
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# ---------------------------------------------------------------------------
+# Burp Suite — binary project and state files produced while exploring atoms.
+# Note: curated `burp/*.txt` request exports ARE committed per atom;
+# only the binary Burp files are ignored here.
+# ---------------------------------------------------------------------------
+
+*.burp
+*.burpstate
+
+# ---------------------------------------------------------------------------
+# Logs — runtime output from apps or CI; never useful in git history.
+# ---------------------------------------------------------------------------
+
+*.log
+logs/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2026 Jose Renato Doreto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OF THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# atomicvulns
+
+<!-- Badges — initial placeholders; more to come (CI, coverage, release, etc.) -->
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+![Status](https://img.shields.io/badge/status-early%20development-orange)
+![Python](https://img.shields.io/badge/python-3.11%2B-blue)
+![OWASP Top 10](https://img.shields.io/badge/OWASP-Top%2010%202021-red)
+
+> ⚠️ **Intentionally vulnerable. Run locally only. Never expose to the internet or a shared network.**
+
+**Read this in other languages:** [Português (Brasil)](./README.pt-BR.md)
+
+## What is atomicvulns?
+
+`atomicvulns` is a collection of *atomic* web applications — each one tiny, isolated, and focused on **a single vulnerability** from the OWASP Top 10. Every atom ships with the vulnerable app, the fixed version, a commented diff between the two, and a hands-on walkthrough of the exploit.
+
+This is **not** another DVWA or Juice Shop. Monolithic vulnerable apps already exist. What sets atomicvulns apart is *radical atomism*: one app per flaw, fast to read, fast to explore. You map code cause → request/response → exploit without having to understand an entire application first.
+
+## Target audience
+
+Junior pentesters and AppSec students who already know the basics of HTTP and the terminal, use (or are learning to use) **Burp Suite**, and want a focused lab where each exercise is short enough to finish in one sitting. The material is written for someone who will apply this in a pentest career — Burp is the primary tool, the UI is just context.
+
+## Running an atom
+
+Each atom lives in its own folder under `atoms/A0X-<category>/<atom-id>/` and ships with a `docker-compose.yml`. A root wrapper script, `./atom`, drives them:
+
+```bash
+./atom list                 # show all available atoms
+./atom up <atom-id>         # start the vulnerable + fixed pair
+./atom down <atom-id>       # stop and remove containers
+./atom doctor               # sanity-check your local setup
+```
+
+For example, to start the first atom:
+
+```bash
+./atom up sqli-union-basic
+# vulnerable → http://127.0.0.1:8001
+# fixed      → http://127.0.0.1:8101
+```
+
+Every atom binds to `127.0.0.1` only. **Never** change that — these apps are intentionally broken.
+
+## Documentation
+
+- **[ROADMAP.md](./ROADMAP.md)** — ordered implementation plan and progress checklist.
+- **[CLAUDE.md](./CLAUDE.md)** — *for contributors:* project briefing, conventions, and ground rules.
+
+## License
+
+Released under the [MIT License](./LICENSE). If you fork this repository for educational material, attribution is required.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,51 @@
+# atomicvulns
+
+<!-- Badges — placeholders iniciais; mais virão (CI, coverage, release, etc.) -->
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+![Status](https://img.shields.io/badge/status-em%20desenvolvimento%20inicial-orange)
+![Python](https://img.shields.io/badge/python-3.11%2B-blue)
+![OWASP Top 10](https://img.shields.io/badge/OWASP-Top%2010%202021-red)
+
+> ⚠️ **Código intencionalmente vulnerável. Rode apenas localmente. Nunca exponha à internet ou a uma rede compartilhada.**
+
+**Este README em outros idiomas:** [English](./README.md)
+
+## O que é o atomicvulns?
+
+`atomicvulns` é uma coleção de aplicações web *atômicas* — cada uma minúscula, isolada e focada em **uma única vulnerabilidade** do OWASP Top 10. Todo átomo entrega a app vulnerável, a versão corrigida, um diff comentado entre as duas e um walkthrough prático do exploit.
+
+Este projeto **não** é mais um DVWA ou Juice Shop. Apps vulneráveis monolíticas já existem. O diferencial do atomicvulns é o *atomismo radical*: uma app por falha, rápida de ler, rápida de explorar. Você mapeia código causal → request/response → exploit sem precisar entender uma aplicação inteira antes.
+
+## Público-alvo
+
+Pentesters júnior e estudantes de AppSec que já sabem o básico de HTTP e terminal, usam (ou estão aprendendo a usar) **Burp Suite**, e querem um laboratório focado onde cada exercício é curto o suficiente para terminar de uma sentada. O material é escrito para quem vai aplicar isso na carreira de pentest — Burp é a ferramenta principal, a UI é só contexto.
+
+## Rodando um átomo
+
+Cada átomo vive em sua própria pasta sob `atoms/A0X-<categoria>/<atom-id>/` e vem com um `docker-compose.yml`. Um script wrapper na raiz, `./atom`, dirige os átomos:
+
+```bash
+./atom list                 # lista todos os átomos disponíveis
+./atom up <atom-id>         # sobe o par vulnerable + fixed
+./atom down <atom-id>       # para e remove os containers
+./atom doctor               # checagem básica do ambiente local
+```
+
+Por exemplo, para subir o primeiro átomo:
+
+```bash
+./atom up sqli-union-basic
+# vulnerable → http://127.0.0.1:8001
+# fixed      → http://127.0.0.1:8101
+```
+
+Todo átomo faz bind apenas em `127.0.0.1`. **Nunca** altere isso — essas apps são intencionalmente quebradas.
+
+## Documentação
+
+- **[ROADMAP.md](./ROADMAP.md)** — plano ordenado de implementação e checklist de progresso.
+- **[CLAUDE.md](./CLAUDE.md)** — *para contribuidores:* briefing do projeto, convenções e regras de base.
+
+## Licença
+
+Publicado sob a [Licença MIT](./LICENSE). Se você forkar este repositório para material didático, atribuição é obrigatória.


### PR DESCRIPTION
## Summary
- Seeds the public-facing repo root so contributors and visitors hit a real entry point before any atoms exist.
- Adds `README.md` / `README.pt-BR.md`, synchronized 1:1 per CLAUDE.md §7, covering what atomicvulns is, the target audience, how to run an atom via `./atom`, and cross-links to `ROADMAP.md` and `CLAUDE.md` (flagged as contributor-facing).
- Adds canonical MIT `LICENSE` (© 2026 Jose Renato Doreto) and a `.gitignore` grouped by Python, Node (for the future JS-only atoms per CLAUDE.md §3.2), SQLite, Docker, IDE/OS noise, Burp binaries, and logs — each section commented.

## Reviewer notes
- Badges are placeholders (License, Status, Python, OWASP); CI / coverage / release badges will be added once the pipelines exist.
- `.gitignore` intentionally ignores only binary Burp files (`*.burp`, `*.burpstate`) — curated `burp/*.txt` request exports stay tracked per atom, per CLAUDE.md §5.
- No `./atom` wrapper script exists yet; the README documents the intended CLI now so the docs don't need a second revision when the wrapper lands.
- `.claude/` (agent worktree infra) is deliberately left untracked.

## Test plan
- [x] GitHub renders both READMEs and the EN↔PT cross-links work.
- [ ] GitHub's license detection picks up `LICENSE` as MIT on the repo page.
- [ ] `.gitignore` categories sanity-checked against the planned stack (Python default, Node for 2 atoms, SQLite, Docker Compose, Burp).