### PR TITLE
chore(repo): ignore .claude/ agent workspace directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,13 @@ desktop.ini
 *.burpstate
 
 # ---------------------------------------------------------------------------
+# Claude Code / agent workspaces — per-session infrastructure (worktrees,
+# scratch state, tooling config). Not part of the project code itself.
+# ---------------------------------------------------------------------------
+
+.claude/
+
+# ---------------------------------------------------------------------------
 # Logs — runtime output from apps or CI; never useful in git history.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `.claude/` to `.gitignore` so the per-session Claude Code workspace (worktrees, scratch state, tooling config) can't be accidentally pulled into a commit via `git add -A`.
- Gave it its own commented section rather than burying it under "IDE noise" — `.claude/` is agent infrastructure, not editor settings, and deserves its own label.

## Reviewer notes
- One-line functional change (`.claude/`) plus 6 lines of section header/blank lines. See the diff.
- If we later decide that part of `.claude/` (e.g. shared skills, hooks, or sub-agent definitions) *should* be versioned, we can invert the pattern with `!.claude/shared/` style exceptions. Not doing that now — nothing in there today is worth sharing.
- Follow-up to #1; splits out because the agent-workspace ignore wasn't on the original checklist you gave me.

## Test plan
- [ ] `git status` in a repo with `.claude/` populated shows no untracked entry for it after this lands.
- [ ] `git check-ignore -v .claude/anything` points to this `.gitignore` line.