### PR TITLE
feat(cli): add ./atom wrapper and align atom README

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Shell-invoked scripts must keep LF (CRLF in shebangs breaks execution on Linux/WSL).
+atom text eol=lf
+Makefile text eol=lf

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: list up down doctor help
+
+PYTHON ?= python3
+
+help:
+	@echo "Usage: make <target> [id=<atom-id>]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  list              Show all available atoms."
+	@echo "  up   id=<atom-id> Start the vulnerable + fixed pair."
+	@echo "  down id=<atom-id> Stop and remove the atom's containers."
+	@echo "  doctor            Sanity-check your local setup."
+
+list:
+	@$(PYTHON) atom list
+
+up:
+	@test -n "$(id)" || (echo "error: pass id=<atom-id>" >&2; exit 1)
+	@$(PYTHON) atom up $(id)
+
+down:
+	@test -n "$(id)" || (echo "error: pass id=<atom-id>" >&2; exit 1)
+	@$(PYTHON) atom down $(id)
+
+doctor:
+	@$(PYTHON) atom doctor

--- a/atom
+++ b/atom
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""atomicvulns CLI wrapper."""
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+ATOMS_DIR = ROOT / "atoms"
+
+USAGE = """usage: atom <command> [args]
+
+Commands:
+  list              Show all available atoms.
+  up <atom-id>      Start the vulnerable + fixed pair (detached).
+  down <atom-id>    Stop and remove the atom's containers.
+  doctor            Sanity-check your local setup.
+"""
+
+
+def find_atoms():
+    atoms = {}
+    if not ATOMS_DIR.is_dir():
+        return atoms
+    for compose in sorted(ATOMS_DIR.glob("*/*/docker-compose.yml")):
+        atom_id = compose.parent.name
+        if atom_id in atoms:
+            sys.exit(
+                f"error: duplicate atom id {atom_id!r} — "
+                f"found in {atoms[atom_id].parent} and {compose.parent}"
+            )
+        atoms[atom_id] = compose
+    return atoms
+
+
+def resolve(atom_id):
+    atoms = find_atoms()
+    if atom_id not in atoms:
+        print(f"error: unknown atom {atom_id!r}", file=sys.stderr)
+        if atoms:
+            print("available atoms:", file=sys.stderr)
+            for i in sorted(atoms):
+                print(f"  {i}", file=sys.stderr)
+        sys.exit(1)
+    return atoms[atom_id]
+
+
+def compose(compose_file, *args):
+    return subprocess.run(
+        ["docker", "compose", "-f", str(compose_file), *args],
+        cwd=compose_file.parent,
+    ).returncode
+
+
+def parse_ports(compose_file):
+    """Return [(service, host_port)] by scanning the compose yaml.
+
+    Assumes the project's standard shape: services: at the top, each service
+    under 2-space indent, ports listed as "127.0.0.1:HOST:CONTAINER".
+    """
+    svc_pat = re.compile(r"^  ([A-Za-z][\w-]*):\s*$")
+    port_pat = re.compile(r'^\s*-\s+"127\.0\.0\.1:(\d+):\d+"\s*$')
+    results = []
+    current_svc = None
+    in_services = False
+    for line in compose_file.read_text(encoding="utf-8").splitlines():
+        if line.rstrip() == "services:":
+            in_services = True
+            continue
+        if not in_services:
+            continue
+        m = svc_pat.match(line)
+        if m:
+            current_svc = m.group(1)
+            continue
+        m = port_pat.match(line)
+        if m and current_svc:
+            results.append((current_svc, int(m.group(1))))
+    return results
+
+
+def cmd_list():
+    atoms = find_atoms()
+    if not atoms:
+        print("No atoms found under atoms/.")
+        return 0
+    width = max(len(i) for i in atoms)
+    print(f"{len(atoms)} atom(s):\n")
+    for atom_id in sorted(atoms):
+        category = atoms[atom_id].parent.parent.name
+        print(f"  {atom_id:<{width}}  {category}")
+    return 0
+
+
+def cmd_up(atom_id):
+    compose_file = resolve(atom_id)
+    print(f"Starting {atom_id}...\n")
+    rc = compose(compose_file, "up", "-d", "--build")
+    if rc != 0:
+        return rc
+    ports = parse_ports(compose_file)
+    if ports:
+        print()
+        width = max(len(svc) for svc, _ in ports)
+        for svc, port in ports:
+            print(f"  {svc:<{width}}  →  http://127.0.0.1:{port}")
+    print()
+    print("Tail logs: docker compose -f", compose_file, "logs -f")
+    return 0
+
+
+def cmd_down(atom_id):
+    compose_file = resolve(atom_id)
+    return compose(compose_file, "down")
+
+
+def cmd_doctor():
+    ok = True
+
+    def check(label, passed, hint=""):
+        nonlocal ok
+        status = "ok" if passed else "FAIL"
+        print(f"  [{status}] {label}")
+        if not passed:
+            if hint:
+                print(f"         {hint}")
+            ok = False
+
+    print("Checking local setup...\n")
+
+    docker = shutil.which("docker")
+    check("docker on PATH", docker is not None, "install Docker Desktop")
+
+    if docker:
+        rc = subprocess.run(
+            ["docker", "compose", "version"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).returncode
+        check(
+            "docker compose v2 available",
+            rc == 0,
+            "update Docker Desktop (Compose V2 ships with it)",
+        )
+
+        rc = subprocess.run(
+            ["docker", "info"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).returncode
+        check("docker daemon reachable", rc == 0, "start Docker Desktop")
+
+    check("atoms/ directory present", ATOMS_DIR.is_dir())
+    atoms = find_atoms()
+    check(
+        f"atoms discovered ({len(atoms)})",
+        len(atoms) > 0,
+        "no docker-compose.yml files found under atoms/*/*/",
+    )
+
+    print("\n" + ("all checks passed." if ok else "some checks failed."))
+    return 0 if ok else 1
+
+
+def main(argv):
+    if len(argv) < 2:
+        print(USAGE, file=sys.stderr)
+        return 1
+    cmd = argv[1]
+    args = argv[2:]
+    if cmd in ("-h", "--help", "help"):
+        print(USAGE)
+        return 0
+    if cmd == "list":
+        return cmd_list()
+    if cmd == "doctor":
+        return cmd_doctor()
+    if cmd in ("up", "down"):
+        if len(args) != 1:
+            print(f"usage: atom {cmd} <atom-id>", file=sys.stderr)
+            return 1
+        return cmd_up(args[0]) if cmd == "up" else cmd_down(args[0])
+    print(f"error: unknown command {cmd!r}\n", file=sys.stderr)
+    print(USAGE, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/atoms/A03-injection/sqli-union-basic/README.md
+++ b/atoms/A03-injection/sqli-union-basic/README.md
@@ -6,13 +6,16 @@ A minimal Flask lab for classic UNION-based SQL injection. A "user profile looku
 
 ## Run
 
+From the repo root:
+
 ```bash
-cd atoms/A03-injection/sqli-union-basic
-docker compose up --build
+./atom up sqli-union-basic
 ```
 
 - Vulnerable app: <http://127.0.0.1:8001/>
 - Fixed app: <http://127.0.0.1:8101/>
+
+Stop with `./atom down sqli-union-basic`. If you prefer raw Docker: `cd atoms/A03-injection/sqli-union-basic && docker compose up --build`.
 
 ## What to read next
 

--- a/atoms/A03-injection/sqli-union-basic/README.pt-BR.md
+++ b/atoms/A03-injection/sqli-union-basic/README.pt-BR.md
@@ -4,15 +4,18 @@
 
 Lab mínimo em Flask para SQL injection clássica via UNION. Um endpoint de "busca de perfil" concatena o parâmetro `username` direto numa query SQL, permitindo ao atacante anexar um `UNION SELECT` e exfiltrar linhas de uma tabela vizinha `secrets` (password hashes, API keys) que a feature nunca pretendeu expor.
 
-## Run
+## Como rodar
+
+Da raiz do repo:
 
 ```bash
-cd atoms/A03-injection/sqli-union-basic
-docker compose up --build
+./atom up sqli-union-basic
 ```
 
 - App vulnerable: <http://127.0.0.1:8001/>
 - App fixed: <http://127.0.0.1:8101/>
+
+Pare com `./atom down sqli-union-basic`. Se preferir Docker cru: `cd atoms/A03-injection/sqli-union-basic && docker compose up --build`.
 
 ## O que ler a seguir
 


### PR DESCRIPTION
## Summary
- Adds `./atom` Python wrapper and `Makefile` implementing the UX promised by the root README (`list`, `up <id>`, `down <id>`, `doctor`). No third-party Python deps.
- After `./atom up`, the wrapper parses the compose yaml and prints each service's host URL (e.g. `vulnerable → http://127.0.0.1:8001`).
- Forces LF line endings on `atom` and `Makefile` via `.gitattributes` so CRLF doesn't break shebang execution when the repo is cloned on Windows and used from WSL.
- Updates `atoms/A03-injection/sqli-union-basic/README.md` and its PT-BR counterpart to lead with `./atom up sqli-union-basic`, keeping the raw `docker compose` command as a fallback. Translates the leftover PT heading `## Run` → `## Como rodar`.

## Why
Before this PR the root README advertised `./atom` commands that didn't exist, and the atom-level README still told readers to `cd ... && docker compose up --build`. The docs and the tooling now agree.

## Test plan
- [x] `./atom doctor` reports all checks ok (docker on PATH, compose v2, daemon reachable, atoms discovered)
- [x] `./atom list` prints `sqli-union-basic  A03-injection`
- [x] `./atom up sqli-union-basic` builds and starts both containers, prints the two `http://127.0.0.1:80xx` URLs
- [x] Both URLs respond; SQLi payloads from the walkthrough still work on `:8001` and are neutralized on `:8101`
- [x] `./atom down sqli-union-basic` stops and removes containers cleanly
- [x] Error paths: `./atom up` with no arg prints usage; `./atom up nonexistent` lists available atoms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>