### PR TITLE
docs: add theory primer linking to PortSwigger Academy per atom

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,32 @@ A solução: incluir um passo no walkthrough que isole a causa real, frequenteme
 
 Esse passo de contraste é obrigatório em todo átomo onde o exploit possa ser confundido com um conceito vizinho.
 
+### Theory primer obrigatório
+
+Todo átomo DEVE incluir, no início do `README.md` e `README.pt-BR.md` do átomo (logo após o título e a descrição de uma linha, ANTES da seção "How to run" / "Como rodar"), um bloco de Theory primer linkando pra página específica da vulnerabilidade na PortSwigger Web Security Academy.
+
+Formato em `README.md`:
+
+```markdown
+> **Theory primer:** Read [PortSwigger: <Nome da vuln>](<URL exata>)
+> before working through this atom. The atoms in this repo show
+> *how* a vulnerability happens in code; the Academy explains *what*
+> it is and why it matters.
+```
+
+Formato em `README.pt-BR.md`:
+
+```markdown
+> **Teoria primeiro:** Leia [PortSwigger: <Nome da vuln>](<URL exata>)
+> antes de fazer este átomo. Os átomos deste repo mostram *como* uma
+> vulnerabilidade acontece no código; a Academy explica *o que* ela é
+> e por que importa.
+```
+
+A URL DEVE ser a página de introdução conceitual da vuln na Academy (tipicamente a que começa com "What is X?"), NÃO a página de listagem de labs. Ao gerar um átomo novo, o Claude Code deve buscar a URL real e nunca inventar — se não conseguir verificar, deve perguntar ao mantenedor.
+
+Para o "<Nome da vuln>" no link, use a forma apresentada pela própria PortSwigger na página (ex.: "SQL injection", "Reflected cross-site scripting", "IDOR", "Server-side request forgery (SSRF)"). NÃO traduza pra PT mesmo no README PT — a página linkada é em inglês, e manter o nome em inglês evita a confusão de "liguei no link e a página tem outro nome".
+
 ---
 
 ## 6. Convenções de nomenclatura

--- a/atoms/A01-broken-access-control/idor-numeric-id/README.md
+++ b/atoms/A01-broken-access-control/idor-numeric-id/README.md
@@ -6,6 +6,11 @@ A minimal Flask lab for classic IDOR. The app serves private notes through `GET 
 
 This is the first atom in the project that is **not input-driven**. There is no malicious payload to craft — the exploit is literally counting `1, 2, 3`. The vulnerability lives in code that *isn't there* (the missing ownership check), not in code that mishandles a string.
 
+> **Theory primer:** Read [PortSwigger: Insecure direct object references (IDOR)](https://portswigger.net/web-security/access-control/idor)
+> before working through this atom. The atoms in this repo show
+> *how* a vulnerability happens in code; the Academy explains *what*
+> it is and why it matters.
+
 ## Stack note — no database
 
 Unlike `sqli-union-basic`, this atom keeps its data in a plain Python list rather than SQLite. IDOR doesn't depend on the storage layer: the bug is a missing authorization check above whichever store you use. The surface is kept minimal so the missing line is obvious. The storage choice in each atom follows the surface of the bug — not the other way around.

--- a/atoms/A01-broken-access-control/idor-numeric-id/README.pt-BR.md
+++ b/atoms/A01-broken-access-control/idor-numeric-id/README.pt-BR.md
@@ -6,6 +6,11 @@ Lab mínimo em Flask para IDOR clássico. A app serve notas privadas via `GET /n
 
 Este é o primeiro átomo do projeto que **não é input-driven**. Não tem payload malicioso pra construir — o exploit é literalmente contar `1, 2, 3`. A vulnerabilidade vive em código que *não está lá* (o ownership check ausente), não em código que maltrata uma string.
 
+> **Teoria primeiro:** Leia [PortSwigger: Insecure direct object references (IDOR)](https://portswigger.net/web-security/access-control/idor)
+> antes de fazer este átomo. Os átomos deste repo mostram *como* uma
+> vulnerabilidade acontece no código; a Academy explica *o que* ela é
+> e por que importa.
+
 ## Nota de stack — sem banco
 
 Diferente do `sqli-union-basic`, este átomo guarda os dados numa lista Python simples em vez de SQLite. IDOR não depende da camada de storage: o bug é um check de autorização ausente acima de qualquer store que você use. A superfície é mantida mínima pra a linha que falta ficar óbvia. A escolha de storage em cada átomo segue a superfície do bug — não o contrário.

--- a/atoms/A03-injection/sqli-union-basic/README.md
+++ b/atoms/A03-injection/sqli-union-basic/README.md
@@ -4,6 +4,11 @@
 
 A minimal Flask lab for classic UNION-based SQL injection. A "user profile lookup" endpoint concatenates the `username` query parameter into a SQL string, letting an attacker append a `UNION SELECT` and exfiltrate rows from a sibling `secrets` table (password hashes, API keys) that the feature never intended to expose.
 
+> **Theory primer:** Read [PortSwigger: SQL injection](https://portswigger.net/web-security/sql-injection)
+> before working through this atom. The atoms in this repo show
+> *how* a vulnerability happens in code; the Academy explains *what*
+> it is and why it matters.
+
 ## Run
 
 From the repo root:

--- a/atoms/A03-injection/sqli-union-basic/README.pt-BR.md
+++ b/atoms/A03-injection/sqli-union-basic/README.pt-BR.md
@@ -4,6 +4,11 @@
 
 Lab mínimo em Flask para SQL injection clássica via UNION. Um endpoint de "busca de perfil" concatena o parâmetro `username` direto numa query SQL, permitindo ao atacante anexar um `UNION SELECT` e exfiltrar linhas de uma tabela vizinha `secrets` (password hashes, API keys) que a feature nunca pretendeu expor.
 
+> **Teoria primeiro:** Leia [PortSwigger: SQL injection](https://portswigger.net/web-security/sql-injection)
+> antes de fazer este átomo. Os átomos deste repo mostram *como* uma
+> vulnerabilidade acontece no código; a Academy explica *o que* ela é
+> e por que importa.
+
 ## Como rodar
 
 Da raiz do repo:

--- a/atoms/A03-injection/xss-reflected/README.md
+++ b/atoms/A03-injection/xss-reflected/README.md
@@ -4,6 +4,11 @@
 
 A minimal Flask lab for classic reflected XSS. A "post search" endpoint echoes the `q` query parameter back into the response page through a Jinja template that marks the value as `|safe`, disabling the autoescape that would normally encode `<`, `>`, `&`, `'`, and `"`. Any HTML or `<script>` the attacker sends in `q` runs in the browser under the app's origin.
 
+> **Theory primer:** Read [PortSwigger: Reflected cross-site scripting (XSS)](https://portswigger.net/web-security/cross-site-scripting/reflected)
+> before working through this atom. The atoms in this repo show
+> *how* a vulnerability happens in code; the Academy explains *what*
+> it is and why it matters.
+
 ## Run
 
 From the repo root:

--- a/atoms/A03-injection/xss-reflected/README.pt-BR.md
+++ b/atoms/A03-injection/xss-reflected/README.pt-BR.md
@@ -4,6 +4,11 @@
 
 Lab mínimo em Flask para reflected XSS clássico. Um endpoint de "busca de posts" ecoa o parâmetro `q` da query string de volta para a página de resposta através de um template Jinja que marca o valor como `|safe`, desligando o autoescape que normalmente encodaria `<`, `>`, `&`, `'` e `"`. Qualquer HTML ou `<script>` que o atacante mande em `q` roda no browser sob a origin da app.
 
+> **Teoria primeiro:** Leia [PortSwigger: Reflected cross-site scripting (XSS)](https://portswigger.net/web-security/cross-site-scripting/reflected)
+> antes de fazer este átomo. Os átomos deste repo mostram *como* uma
+> vulnerabilidade acontece no código; a Academy explica *o que* ela é
+> e por que importa.
+
 ## Como rodar
 
 Da raiz do repo:

--- a/atoms/A10-ssrf/ssrf-basic/README.md
+++ b/atoms/A10-ssrf/ssrf-basic/README.md
@@ -6,6 +6,11 @@ A minimal Flask lab for classic SSRF. The app exposes a "URL preview" feature �
 
 This is the first atom in the project where the **server itself** is the one making the outbound request. In `sqli-union-basic`, `xss-reflected`, and `idor-numeric-id` the attacker sent a payload that the app processed locally. In SSRF the attacker sends a *URL*, and the app turns around and makes an HTTP request *to that URL* on its own. The threat shape changes: now the attacker's reach equals the server's reach — internal services, cloud metadata endpoints, anything the server's network can see.
 
+> **Theory primer:** Read [PortSwigger: Server-side request forgery (SSRF)](https://portswigger.net/web-security/ssrf)
+> before working through this atom. The atoms in this repo show
+> *how* a vulnerability happens in code; the Academy explains *what*
+> it is and why it matters.
+
 ## Lab structure — three containers
 
 This is also the first multi-container atom. Three services come up under one `docker-compose.yml`:

--- a/atoms/A10-ssrf/ssrf-basic/README.pt-BR.md
+++ b/atoms/A10-ssrf/ssrf-basic/README.pt-BR.md
@@ -6,6 +6,11 @@ Lab mínimo em Flask para SSRF clássico. A app expõe uma feature de "URL previ
 
 Este é o primeiro átomo do projeto em que o **servidor em si** é quem faz o request de saída. Em `sqli-union-basic`, `xss-reflected` e `idor-numeric-id`, o atacante mandava um payload que a app processava localmente. Em SSRF o atacante manda uma *URL*, e a app por conta própria faz um request HTTP *pra essa URL*. A forma da ameaça muda: agora o alcance do atacante é igual ao alcance do servidor — serviços internos, endpoints de cloud metadata, qualquer coisa que a rede do servidor enxerga.
 
+> **Teoria primeiro:** Leia [PortSwigger: Server-side request forgery (SSRF)](https://portswigger.net/web-security/ssrf)
+> antes de fazer este átomo. Os átomos deste repo mostram *como* uma
+> vulnerabilidade acontece no código; a Academy explica *o que* ela é
+> e por que importa.
+
 ## Estrutura do lab — três containers
 
 Este é também o primeiro átomo multi-container. Três serviços sobem num único `docker-compose.yml`:


### PR DESCRIPTION
## Summary

- New project rule (`CLAUDE.md` §5, "Theory primer obrigatório") requiring every atom README to include a quote-block link to the corresponding PortSwigger Web Security Academy intro page (the conceptual "What is X?" page, not the labs listing).
- Applied retroactively to all 4 published atoms (`sqli-union-basic`, `xss-reflected`, `idor-numeric-id`, `ssrf-basic`) in both languages so the repo stays consistent — no temporary state where some atoms have the primer and others don't.

## Why

The repo's root READMEs already recommend reading the Academy before each atom, but the student had to find the right page themselves. The Theory primer eliminates that friction and makes the "*how* (this repo) vs. *what/why* (Academy)" split explicit at the top of every atom.

## Notes for reviewer

- All 4 PortSwigger URLs were verified by fetching each page and reading its actual H1 — no guessed URLs. The link label uses PortSwigger's own naming, with `Reflected XSS` expanded to `Reflected cross-site scripting (XSS)` for visual consistency with the other three (which all carry the full name + parenthesized acronym).
- Vulnerability names stay in English even in `README.pt-BR.md` — the linked page is in English, and matching names avoids the "I clicked the link and the page has a different name" confusion.
- Insertion point: right before the first `##` heading of each README (`## Run` for SQLi/XSS, `## Stack note — no database` for IDOR, `## Lab structure — three containers` for SSRF). The Theory primer is intro material — it belongs with the orientation, not buried mid-README.
- The new rule kicks in automatically for the next atom (`sqli-blind-boolean`, next in the roadmap).

## Test plan

- [ ] Click each PortSwigger link in the rendered READMEs and confirm it lands on the intended conceptual intro page (not a lab, not a 404).
- [ ] Skim the rendered Markdown of each modified README to confirm the blockquote renders correctly and spacing looks right.
- [ ] Re-read `CLAUDE.md` §5 "Theory primer obrigatório" and confirm the rule is unambiguous for the next atom author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)