### PR TITLE
docs: add SECURITY and CONTRIBUTING policies (EN+PT)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to atomicvulns
+
+**Read this in other languages:** [Português (Brasil)](./CONTRIBUTING.pt-BR.md)
+
+Thanks for your interest. This document explains how to contribute effectively.
+
+## What kinds of contributions are welcome
+
+- **New atoms** that follow the atomism principle: one vulnerability per app (see [CLAUDE.md §2](./CLAUDE.md))
+- **Translations** of existing atom content (PT-BR, or new languages)
+- **Improvements to walkthroughs and DIFFs** — clarity, accuracy, pedagogical value
+- **Wrapper script (`./atom`) improvements**
+- **CI and infrastructure work** listed under "Infraestrutura e governança" in [ROADMAP.md](./ROADMAP.md)
+- **Bug fixes in lab infrastructure** (compose, networking, wrapper)
+
+## What is NOT welcome
+
+- "Fixing" the vulnerabilities in atoms — they're intentional
+- Atoms that bundle multiple vulnerabilities — violates atomism; split them
+- Heavy-framework rewrites (Django instead of Flask, TypeScript instead of Python) — the project picked its stack on purpose (see CLAUDE.md §3)
+- Performance optimizations — lab apps are intentionally simple, not fast
+- UI improvements beyond the minimum HTML the project allows (see CLAUDE.md §3.3)
+
+## Before opening an issue
+
+- **Design discussion or proposal:** open a Discussion, not an Issue
+- **New atom proposal:** check [ROADMAP.md](./ROADMAP.md) first — it may already be planned. If not, open a Discussion to propose
+- **Bug in lab infrastructure** (wrapper, compose, networking): open an Issue with reproduction steps
+- **Security issue:** see [SECURITY.md](./SECURITY.md)
+
+## How to propose a new atom
+
+1. Check [ROADMAP.md](./ROADMAP.md) for the atom you want to build, or for the next available slot
+2. Open a Discussion to confirm scope and approach with the maintainer
+3. Once aligned, follow the workflow in [CLAUDE.md §10](./CLAUDE.md). This project is built with Claude Code, but you don't need it — the same template and conventions apply to human contributors
+4. The atom must include: working `vulnerable/` + `fixed/` versions, `WALKTHROUGH.md` (EN+PT), `DIFF.md` (EN+PT), `README.md` (EN+PT), `docker-compose.yml`, and the Theory primer block linking PortSwigger Academy (see [CLAUDE.md §5](./CLAUDE.md))
+
+## Workflow
+
+1. Fork the repo
+2. Create a feature branch: `feat/atom-id`, `docs/...`, `fix/...`, etc.
+3. Commit using [Conventional Commits](https://www.conventionalcommits.org/) (see [CLAUDE.md §6](./CLAUDE.md) for examples)
+4. Open a Pull Request against `main`
+5. Wait for review. The maintainer validates every atom manually via Burp before merge, which can take from a day to a couple of weeks depending on availability. Be patient; this is a personal project.
+
+## Style
+
+- **Python:** PEP 8. No formal linter — the codebase is tiny, judgment beats tooling
+- **Markdown:** wrap lines around 80 chars where reasonable; don't fight the wrap when prose flows better long
+- **Commit messages:** Conventional Commits in English (`feat(scope): ...`, `docs: ...`, etc.)
+- **Documentation language:** English code, English + PT-BR docs, synchronized in the same commit (see [CLAUDE.md §7](./CLAUDE.md))
+
+## License
+
+By contributing, you agree your contributions are licensed under the project's [MIT License](./LICENSE).

--- a/CONTRIBUTING.pt-BR.md
+++ b/CONTRIBUTING.pt-BR.md
@@ -1,0 +1,55 @@
+# Contribuindo com o atomicvulns
+
+**Este documento em outros idiomas:** [English](./CONTRIBUTING.md)
+
+Obrigado pelo interesse. Este documento explica como contribuir de forma efetiva.
+
+## Que tipos de contribuição são bem-vindos
+
+- **Átomos novos** que sigam o princípio de atomismo: uma vulnerabilidade por app (ver [CLAUDE.md §2](./CLAUDE.md))
+- **Traduções** de conteúdo existente (PT-BR ou idiomas novos)
+- **Melhorias em walkthroughs e DIFFs** — clareza, precisão, valor pedagógico
+- **Melhorias no script wrapper (`./atom`)**
+- **Trabalho de CI e infraestrutura** listado em "Infraestrutura e governança" no [ROADMAP.md](./ROADMAP.md)
+- **Bug fixes na infraestrutura dos labs** (compose, networking, wrapper)
+
+## O que NÃO é bem-vindo
+
+- "Consertar" as vulnerabilidades dos átomos — elas são intencionais
+- Átomos que combinam múltiplas vulnerabilidades — viola o atomismo; separe em átomos diferentes
+- Reescritas com framework pesado (Django em vez de Flask, TypeScript em vez de Python) — o projeto escolheu a stack de propósito (ver CLAUDE.md §3)
+- Otimizações de performance — apps de lab são intencionalmente simples, não rápidas
+- Melhorias de UI além do mínimo de HTML que o projeto permite (ver CLAUDE.md §3.3)
+
+## Antes de abrir uma issue
+
+- **Discussão de design ou proposta:** abra uma Discussion, não uma Issue
+- **Proposta de átomo novo:** confira o [ROADMAP.md](./ROADMAP.md) primeiro — pode já estar planejado. Se não estiver, abra uma Discussion para propor
+- **Bug na infraestrutura dos labs** (wrapper, compose, networking): abra uma Issue com passos de reprodução
+- **Issue de segurança:** ver [SECURITY.md](./SECURITY.md)
+
+## Como propor um átomo novo
+
+1. Confira o [ROADMAP.md](./ROADMAP.md) pelo átomo que você quer construir, ou pelo próximo slot disponível
+2. Abra uma Discussion para alinhar escopo e abordagem com o mantenedor
+3. Uma vez alinhado, siga o workflow da [CLAUDE.md §10](./CLAUDE.md). Este projeto é construído com Claude Code, mas você não precisa usar — o mesmo template e convenções valem para contribuidores humanos
+4. O átomo deve incluir: versões `vulnerable/` + `fixed/` funcionais, `WALKTHROUGH.md` (EN+PT), `DIFF.md` (EN+PT), `README.md` (EN+PT), `docker-compose.yml` e o bloco Theory primer linkando a PortSwigger Academy (ver [CLAUDE.md §5](./CLAUDE.md))
+
+## Fluxo
+
+1. Forke o repo
+2. Crie uma feature branch: `feat/atom-id`, `docs/...`, `fix/...`, etc.
+3. Commit usando [Conventional Commits](https://www.conventionalcommits.org/) (ver [CLAUDE.md §6](./CLAUDE.md) para exemplos)
+4. Abra um Pull Request contra `main`
+5. Aguarde a revisão. O mantenedor valida todo átomo manualmente via Burp antes do merge, o que pode levar de um dia a algumas semanas dependendo da disponibilidade. Tenha paciência; este é um projeto pessoal.
+
+## Estilo
+
+- **Python:** PEP 8. Sem linter formal — a codebase é minúscula, julgamento vale mais que ferramenta
+- **Markdown:** quebra de linha por volta dos 80 caracteres quando razoável; não force a quebra quando a prosa flui melhor com linha longa
+- **Mensagens de commit:** Conventional Commits em inglês (`feat(scope): ...`, `docs: ...`, etc.)
+- **Idioma da documentação:** código em inglês, docs em inglês + PT-BR, sincronizadas no mesmo commit (ver [CLAUDE.md §7](./CLAUDE.md))
+
+## Licença
+
+Ao contribuir, você concorda que sua contribuição seja licenciada sob a [Licença MIT](./LICENSE) do projeto.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+**Read this in other languages:** [Português (Brasil)](./SECURITY.pt-BR.md)
+
+## This is an intentionally vulnerable project
+
+The applications under `atoms/` are deliberately broken for educational purposes. **Do not report the vulnerabilities in atoms as security issues** — every flaw is intentional and documented in the atom's `WALKTHROUGH.md` and `DIFF.md`.
+
+If you're unsure whether a given behavior is an intentional lab feature or a real bug, check the atom's `WALKTHROUGH.md` first. If the behavior is described there, it's the lab.
+
+## What counts as a security issue here
+
+The following are legitimate to report:
+
+- Vulnerabilities in the wrapper script (`./atom`) that could affect the host running the labs
+- Network bind misconfigurations — anything binding to `0.0.0.0` instead of `127.0.0.1` (see [CLAUDE.md §8](./CLAUDE.md))
+- Container escape paths in the lab infrastructure itself
+- Cross-contamination between atoms — one atom's container reaching another's network when it shouldn't
+- Supply-chain risks in build dependencies of the wrapper or shared infrastructure
+- Issues in CI or repository tooling (once present)
+
+## Permission to test
+
+You're explicitly authorized to probe the wrapper, infrastructure, and build pipeline for issues falling under the categories above. Probing the atoms themselves is the intended use of the project, so no permission needed there.
+
+Do not probe atomicvulns infrastructure that isn't this repo (e.g. anything on a domain like `atomicvulns.com` if one exists). The project is the code in this repository, period.
+
+## How to report
+
+Use **[GitHub Security Advisories](https://github.com/doretox/atomicvulns/security/advisories/new)** to open a private report. This keeps the discussion off the public issue tracker until a fix is in place.
+
+If that interface isn't available for any reason, open a regular issue with the title prefixed by "Security:" and **no technical details** — I'll move it to a private channel.
+
+Please include:
+
+- A short description of the issue and its impact
+- Reproduction steps (commands, requests, expected vs. actual behavior)
+- The commit SHA you tested against
+
+## What to expect
+
+- Acknowledgement within a few days
+- Coordinated public disclosure once the fix is in place
+- Credit in the release notes, if you want it
+
+## What not to expect
+
+- A bug bounty — this is a free educational project
+- Fixes for "vulnerabilities" inside the labs themselves — those *are* the lab
+
+## Responsible use
+
+The atoms exist to teach. Running them on infrastructure you don't own, deploying them on public networks, or using techniques learned here against systems without authorization is illegal in most jurisdictions and against the spirit of this project.

--- a/SECURITY.pt-BR.md
+++ b/SECURITY.pt-BR.md
@@ -1,0 +1,53 @@
+# Política de Segurança
+
+**Este documento em outros idiomas:** [English](./SECURITY.md)
+
+## Este é um projeto intencionalmente vulnerável
+
+As aplicações em `atoms/` são deliberadamente quebradas para fins educacionais. **Não reporte as vulnerabilidades dos átomos como problemas de segurança** — toda falha é intencional e está documentada no `WALKTHROUGH.md` e no `DIFF.md` do átomo.
+
+Se você não tem certeza se um comportamento é feature intencional do lab ou bug real, confira o `WALKTHROUGH.md` do átomo primeiro. Se o comportamento estiver descrito lá, é o lab.
+
+## O que conta como problema de segurança aqui
+
+Os seguintes são reports legítimos:
+
+- Vulnerabilidades no script wrapper (`./atom`) que possam afetar o host rodando os labs
+- Misconfigurations de bind de rede — qualquer coisa bindando em `0.0.0.0` em vez de `127.0.0.1` (ver [CLAUDE.md §8](./CLAUDE.md))
+- Caminhos de container escape na infraestrutura do lab em si
+- Contaminação cruzada entre átomos — o container de um átomo alcançando a rede de outro quando não deveria
+- Riscos de supply chain nas dependências de build do wrapper ou da infraestrutura compartilhada
+- Issues em CI ou tooling do repositório (quando existirem)
+
+## Permissão para testar
+
+Você está explicitamente autorizado a testar o wrapper, a infraestrutura e o pipeline de build em busca de problemas que se enquadrem nas categorias acima. Testar os átomos em si é o uso pretendido do projeto, então não precisa de permissão pra isso.
+
+Não teste infraestrutura do atomicvulns que não seja este repositório (ex.: qualquer coisa em um domínio tipo `atomicvulns.com` se vier a existir). O projeto é o código deste repositório, ponto.
+
+## Como reportar
+
+Use **[GitHub Security Advisories](https://github.com/doretox/atomicvulns/security/advisories/new)** para abrir um report privado. Isso mantém a discussão fora do issue tracker público até o fix entrar.
+
+Se essa interface não estiver disponível por algum motivo, abra uma issue normal com o título prefixado por "Security:" e **sem detalhes técnicos** — vou mover para um canal privado.
+
+Inclua:
+
+- Descrição curta do issue e do impacto
+- Passos de reprodução (comandos, requests, comportamento esperado vs. atual)
+- O SHA do commit que você testou
+
+## O que esperar
+
+- Reconhecimento em alguns dias
+- Disclosure público coordenado quando o fix estiver em produção
+- Crédito nas release notes, se quiser
+
+## O que NÃO esperar
+
+- Bug bounty — este é um projeto educacional gratuito
+- Fixes para "vulnerabilidades" dentro dos labs — elas *são* o lab
+
+## Uso responsável
+
+Os átomos existem pra ensinar. Rodar eles em infraestrutura que você não é dono, deployar em redes públicas, ou usar técnicas aprendidas aqui contra sistemas sem autorização é ilegal na maioria das jurisdições e contra o espírito deste projeto.


### PR DESCRIPTION
Adds standard project governance docs before going public.

## What's included

- `SECURITY.md` + `SECURITY.pt-BR.md`
- `CONTRIBUTING.md` + `CONTRIBUTING.pt-BR.md`

## Key design decisions

- **SECURITY**: makes explicit that atom flaws are intentional (not bugs), defines what IS in scope (wrapper, infrastructure, CI), gives permission to test, points to GitHub Security Advisories with a fallback path.
- **CONTRIBUTING**: routes the contributor to Discussion vs Issue vs Security, ties new-atom workflow to CLAUDE.md sections, sets honest expectations on review time ("a day to a couple of weeks").

## Style

- Bilingual following the project pattern (EN as primary, PT-BR cross-linked).
- Technical terms preserved in English on PT versions (per CLAUDE.md §7).
- No "intentionally vulnerable" banner on these docs (banner is for app surfaces, not governance docs).

Last batch of pre-v0.1 housekeeping before turning the repo public.
