### PR TITLE
docs: use inclusive audience language across project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 
 **O que NÃO é:** não é um DVWA/Juice Shop concorrente. Apps vulneráveis monolíticas já existem. O diferencial deste projeto é o *atomismo radical*: uma app por falha, rápida de ler, rápida de explorar.
 
-**Público-alvo:** pentesters júnior (incluindo estudantes de pentest/AppSec) que já sabem o básico de HTTP e terminal, usam (ou estão aprendendo a usar) Burp Suite, e querem mapear *código causal → request/response → exploit* sem precisar entender uma aplicação inteira primeiro. O tom do material assume alguém que vai aplicar isso na carreira de pentest.
+**Público-alvo:** estudantes de pentest e AppSec que já sabem o básico de HTTP e terminal, usam (ou estão aprendendo a usar) Burp Suite, e querem mapear *código causal → request/response → exploit* sem precisar entender uma aplicação inteira primeiro. O tom do material assume alguém que vai aplicar isso na carreira de pentest.
 
 **Mantenedor:** projeto solo, médio/longo prazo.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is **not** another DVWA or Juice Shop. Monolithic vulnerable apps already e
 
 ## Target audience
 
-Junior pentesters and AppSec students who already know the basics of HTTP and the terminal, use (or are learning to use) **Burp Suite**, and want a focused lab where each exercise is short enough to finish in one sitting. The material is written for someone who will apply this in a pentest career — Burp is the primary tool, the UI is just context.
+Pentest students and AppSec learners who already know the basics of HTTP and the terminal, use (or are learning to use) **Burp Suite**, and want a focused lab where each exercise is short enough to finish in one sitting. The material is written for someone who will apply this in a pentest career — Burp is the primary tool, the UI is just context.
 
 ## Running an atom
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -20,7 +20,7 @@ Este projeto **não** é mais um DVWA ou Juice Shop. Apps vulneráveis monolíti
 
 ## Público-alvo
 
-Pentesters júnior e estudantes de AppSec que já sabem o básico de HTTP e terminal, usam (ou estão aprendendo a usar) **Burp Suite**, e querem um laboratório focado onde cada exercício é curto o suficiente para terminar de uma sentada. O material é escrito para quem vai aplicar isso na carreira de pentest — Burp é a ferramenta principal, a UI é só contexto.
+Estudantes de pentest e de AppSec que já sabem o básico de HTTP e terminal, usam (ou estão aprendendo a usar) **Burp Suite**, e querem um laboratório focado onde cada exercício é curto o suficiente para terminar de uma sentada. O material é escrito para quem vai aplicar isso na carreira de pentest — Burp é a ferramenta principal, a UI é só contexto.
 
 ## Rodando um átomo
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,7 +49,7 @@ Legenda:
 
 ## Fase 2 — Aprofundamento em Injection
 
-**Objetivo:** dominar as variantes blind e side-channels, que são o que separa pentester júnior de pleno em relatórios de SQLi/command injection.
+**Objetivo:** dominar as variantes blind e side-channels, que são o que diferencia um relatório básico de SQLi/command injection de um relatório de nível profissional.
 
 **Milestone:** `v0.2 — Injection Deep Dive`
 

--- a/docs/prompts/PROMPTS.md
+++ b/docs/prompts/PROMPTS.md
@@ -389,7 +389,7 @@ Me dê uma avaliação honesta:
 ### 8.3. Sanity check no tom/didática do walkthrough
 
 ```
-Leia WALKTHROUGH.md do átomo `<id>` e critique com olhos de pentester júnior (não júnior absoluto — já fez uns 3-5 átomos).
+Leia WALKTHROUGH.md do átomo `<id>` e critique com olhos de estudante de pentest que já passou da fase inicial (já fez uns 3-5 átomos).
 
 Aponte:
 - Passos que pularam explicação.


### PR DESCRIPTION
Replaces "junior pentester" / "pentester júnior" with audience language that does not label seniority.

## Why

The term "junior" can read as either a seniority label or as condescending, when the actual intent is to describe people learning pentest — self-taught, formal students, professionals in transition. Removing the label broadens the implied audience without losing clarity.

## What changed

- `README.md` / `README.pt-BR.md`: target audience section reworded ("Pentest students and AppSec learners" / "Estudantes de pentest e de AppSec").
- `CLAUDE.md`: público-alvo section reworded; redundant parenthetical removed.
- `ROADMAP.md`: Phase 2 objective now compares **reports** (basic vs. professional-grade) instead of **people** (junior vs. mid-level), keeping the technical point intact without using seniority labels at all.
- `docs/prompts/PROMPTS.md`: internal prompt template uses "estudante de pentest que já passou da fase inicial" instead of paired "júnior"/"não júnior absoluto" labels.

## What is preserved

- The project name "MVP Pentester" (used as v0.1 phase name in `ROADMAP.md` and `CHANGELOG.md`) — it's a canonical fase name, not audience description.
- Other contextual mentions of words like "iniciante" that describe a learning stage rather than the project's target audience.

5 files changed, +5/-5.
