### PR TITLE
docs(atom-02): use html fence for jinja template block

### DIFF
--- a/atoms/A03-injection/xss-reflected/WALKTHROUGH.md
+++ b/atoms/A03-injection/xss-reflected/WALKTHROUGH.md
@@ -18,7 +18,7 @@ def search():
 
 The source is obvious (`request.args.get("q", "")`), but there's no unescaped concatenation in the view itself. The sink lives one file over, in [`vulnerable/templates/search.html`](./vulnerable/templates/search.html):
 
-```jinja
+```html
 <h1>Results for: {{ q|safe }}</h1>
 ```
 

--- a/atoms/A03-injection/xss-reflected/WALKTHROUGH.pt-BR.md
+++ b/atoms/A03-injection/xss-reflected/WALKTHROUGH.pt-BR.md
@@ -18,7 +18,7 @@ def search():
 
 A source é óbvia (`request.args.get("q", "")`), mas não tem concatenação unescaped na view em si. O sink está a um arquivo de distância, em [`vulnerable/templates/search.html`](./vulnerable/templates/search.html):
 
-```jinja
+```html
 <h1>Results for: {{ q|safe }}</h1>
 ```
 


### PR DESCRIPTION
Cosmetic fix. The template block in atom-02's walkthrough used a
` ```jinja ` fence, but GitHub's highlighter has no `jinja` lexer,
so the block rendered unstyled. Switched to ` ```html ` (the other
template blocks in the same walkthrough already use it). Applied
to EN and PT-BR in sync.

No code or content change — fence language only.