### PR TITLE
Fix jwt-none-alg foreshadow debt (unpublished-atom reference)

### DIFF
--- a/atoms/A02-cryptographic-failures/jwt-none-alg/WALKTHROUGH.md
+++ b/atoms/A02-cryptographic-failures/jwt-none-alg/WALKTHROUGH.md
@@ -155,7 +155,7 @@ Response: `200 OK`, the admin panel HTML — `Pretend admin key`, pending approv
 
 ## 5. What just happened — the deeper bug
 
-The surface bug — "the app accepts unsigned tokens" — explains what worked. The shape of the bug is bigger than that, and worth a minute of attention because atoms 13 and 14 will exploit other flavors of the same shape.
+The surface bug — "the app accepts unsigned tokens" — explains what worked. The shape of the bug is bigger than that, and worth a minute of attention because the same shape recurs across other JWT flaws.
 
 **This is the first atom in the project where the bug is a crypto-config failure, not an input or logic failure.** In atoms 01–04 the broken thing was concrete: an unsanitized SQL string, an unescaped HTML expression, a missing ownership check, an unrestricted outbound URL. Here the code is full of crypto: secrets, signatures, HMAC. None of it is broken. The problem is that the server agreed to do *no* crypto when the token said so. **Looks-like-crypto is not is-crypto.** A `jwt.decode(...)` call surrounded by a `SECRET` constant and an `algorithms=` parameter looks like a security boundary; if any path through the function returns parsed claims without verifying a signature, it isn't.
 

--- a/atoms/A02-cryptographic-failures/jwt-none-alg/WALKTHROUGH.pt-BR.md
+++ b/atoms/A02-cryptographic-failures/jwt-none-alg/WALKTHROUGH.pt-BR.md
@@ -155,7 +155,7 @@ Response: `200 OK`, o HTML do painel admin — `Pretend admin key`, approvals pe
 
 ## 5. O que aconteceu de verdade — o bug mais fundo
 
-O bug de superfície — "a app aceita tokens sem assinatura" — explica o que funcionou. A forma do bug é maior que isso, e merece um minuto de atenção porque os átomos 13 e 14 vão explorar outras variantes da mesma forma.
+O bug de superfície — "a app aceita tokens sem assinatura" — explica o que funcionou. A forma do bug é maior que isso, e merece um minuto de atenção porque a mesma forma reaparece em outras falhas de JWT.
 
 **Este é o primeiro átomo do projeto onde o bug é uma falha de configuração criptográfica, não de input nem de lógica.** Nos átomos 01–04 a coisa quebrada era concreta: uma string SQL não-sanitizada, uma expressão HTML sem escape, um check de ownership ausente, uma URL de saída irrestrita. Aqui o código é todo crypto: secrets, signatures, HMAC. Nada disso está quebrado. O problema é que o servidor aceitou *não fazer* crypto quando o token pediu. **Parece-crypto não é é-crypto.** Uma chamada `jwt.decode(...)` cercada por uma constante `SECRET` e um parâmetro `algorithms=` parece um security boundary; se qualquer caminho pela função retorna claims parseadas sem verificar uma signature, não é.
 


### PR DESCRIPTION
The jwt-none-alg (05) WALKTHROUGH §5 foreshadowed atoms 13 and 14 by number, violating the repo's no-unpublished-atom-references policy (CLAUDE.md). Generalizes the bug-shape note to reference the class of JWT flaws instead of specific atom numbers — a timeless statement that won't break as the roadmap evolves. EN and PT-BR synchronized. This clears the debt recorded in the atom-13 spec and project memory.