### PR TITLE
docs(atom-16): remove forward reference in walkthrough

### DIFF
--- a/atoms/A10-ssrf/ssrf-blind-oob/WALKTHROUGH.md
+++ b/atoms/A10-ssrf/ssrf-blind-oob/WALKTHROUGH.md
@@ -136,7 +136,7 @@ Because the exploit produces no visible loot, it is easy to draw the wrong lesso
 
 Blind SSRF means the server can be coerced into making arbitrary outbound requests to destinations the attacker picks, without the attacker seeing the response. On its own, that is what this atom demonstrates: **detection of the primitive** — proof that the server will reach out on your command.
 
-The listener here is a tripwire, not a prize; it holds nothing to steal. Turning this reach into real damage — pointing the server at internal services, or at a cloud metadata endpoint to lift credentials — is a *separate* escalation step beyond this atom's scope. This atom stops at the primitive: the confirmed callback. It is **not** RCE, and nothing here should be over-claimed as more than "the server made a request I chose, and I proved it".
+The listener here is a tripwire, not a prize; it holds nothing to steal. This atom stops at the primitive — the confirmed callback, proof that the server made a request you chose. That is the honest ceiling: it is not RCE, and nothing here should be over-claimed beyond "I made the server reach a destination I picked, and I proved it out-of-band".
 
 ## 7. Exploitation via browser (secondary track, optional)
 

--- a/atoms/A10-ssrf/ssrf-blind-oob/WALKTHROUGH.pt-BR.md
+++ b/atoms/A10-ssrf/ssrf-blind-oob/WALKTHROUGH.pt-BR.md
@@ -136,7 +136,7 @@ Como o exploit não produz loot visível, é fácil tirar a lição errada. Crav
 
 Blind SSRF significa que o servidor pode ser coagido a fazer requisições outbound arbitrárias pra destinos que o atacante escolhe, sem o atacante ver a resposta. Por si só, é isso que este átomo demonstra: **detecção da primitiva** — a prova de que o servidor sai pra fora sob o seu comando.
 
-O listener aqui é uma tripwire, não um prêmio; não tem nada pra roubar. Transformar esse alcance em dano real — apontar o servidor pra serviços internos, ou pra um endpoint de metadata de cloud pra levantar credenciais — é um passo de escalada *separado*, além do escopo deste átomo. Este átomo para na primitiva: o callback confirmado. **Não** é RCE, e nada aqui deve ser superestimado além de "o servidor fez uma requisição que eu escolhi, e eu provei".
+O listener aqui é uma tripwire, não um prêmio; não tem nada pra roubar. Este átomo para na primitiva — o callback confirmado, a prova de que o servidor fez uma requisição que você escolheu. Esse é o teto honesto: não é RCE, e nada aqui deve ser superestimado além de "fiz o servidor alcançar um destino que eu escolhi, e provei out-of-band".
 
 ## 7. Exploração via browser (trilha secundária, opcional)
 


### PR DESCRIPTION
Fecha a lição do blind-oob no primitivo (callback confirmado) sem gesticular pra escalada de átomo futuro. Conteúdo do aluno só referencia átomos publicados.