### PR TITLE
docs(i18n): translate remaining pt-BR section headers and formalize the rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,6 +329,8 @@ Regras claras para evitar inconsistência:
 
 **Título h1 do `README.pt-BR.md` é idêntico ao do `README.md`** (sem tradução). O resto do documento — tagline/descrição, parágrafos, headers de seção — é traduzido normalmente. Razão: o nome canônico de uma classe de vulnerabilidade circula em inglês na comunidade de segurança ("Reflected Cross-Site Scripting", "Server-Side Request Forgery"); preservar no título evita ambiguidade terminológica, mantém consistência com IDs de átomo (que já são em inglês) e elimina a tentação de inventar uma tradução por átomo.
 
+**Headers de seção são traduzidos em TODA doc PT** — `README.pt-BR.md`, `WALKTHROUGH.pt-BR.md` e `DIFF.pt-BR.md`. A única exceção é o h1 do README, coberto pela regra acima. Termos técnicos seguem em inglês DENTRO do header traduzido: `### Passo 1 — Confirmar o injection point`, `## Por que o fix funciona`, `### Baseline — limpo, capturado primeiro`. Sinal de tradução não aplicada: um header de seção byte-idêntico ao do arquivo EN.
+
 **Sincronização:** ao editar uma versão da doc, o Claude Code deve atualizar a contraparte no mesmo commit. Nunca deixar PT e EN dessincronizados.
 
 ---
@@ -432,6 +434,7 @@ Todo átomo passa por este checklist manual antes de ir pro `main`:
 - [ ] WALKTHROUGH tem trilha Burp como principal.
 - [ ] Todas as portas bindam em `127.0.0.1`.
 - [ ] PT e EN estão sincronizados (mesma informação, mesma estrutura).
+- [ ] Nenhum header de seção (`##`/`###`/`####`) do arquivo PT é byte-idêntico ao par EN (o h1 do README é a única exceção).
 - [ ] Sem credenciais reais, sem dados sensíveis de clientes.
 - [ ] Átomo marcado como concluído em `ROADMAP.md`.
 
@@ -462,7 +465,7 @@ Para manter o escopo saudável:
 
 Este arquivo evolui com o projeto. Toda mudança estrutural (novo padrão, nova convenção, nova regra) é refletida aqui no mesmo PR que a introduz. Se o Claude Code observa conflito entre o que está aqui e o que foi pedido na sessão, ele para e pergunta.
 
-**Última revisão:** dia de criação do repositório.
+**Última revisão:** 2026-08-04.
 **Responsável:** mantenedor (Jose Renato).
 
 ## Memória de projeto

--- a/atoms/A01-broken-access-control/bola-rest/DIFF.pt-BR.md
+++ b/atoms/A01-broken-access-control/bola-rest/DIFF.pt-BR.md
@@ -25,7 +25,7 @@
 
 A view fixed compara o `owner` do pedido com o caller autenticado e recusa um mismatch. Esse único condicional fecha o BOLA: a classe é "o servidor devolve um objeto escopado a usuário sem checar que o caller é o dono", e a remediação é exatamente a negação disso.
 
-## Authenticated ≠ authorized — dá pra ver no diff
+## Autenticado ≠ autorizado — dá pra ver no diff
 
 Olhe a primeira linha que mudou: `_authenticate()` virou `caller = _authenticate()`. É a lição inteira numa edição.
 

--- a/atoms/A01-broken-access-control/csrf-basic/WALKTHROUGH.pt-BR.md
+++ b/atoms/A01-broken-access-control/csrf-basic/WALKTHROUGH.pt-BR.md
@@ -2,7 +2,7 @@
 
 O alvo é uma página de conta com uma ação: trocar o e-mail de recuperação. Você loga, digita um novo e-mail, e o `POST /email` atualiza a conta. O servidor sabe que é você porque o browser mandou o **cookie de sessão** — o valor que ele guardou no login e reenvia automaticamente em toda request pra este site. Esse reenvio automático é o problema inteiro: o browser anexa o cookie não importa *qual site* causou a request. Uma página em outro site pode conter um `<form>` escondido que dispara um `POST /email` neste alvo a partir do browser da vítima, e o browser vai anexar o cookie de sessão da vítima nele. O servidor vê um cookie válido e troca o e-mail — como se a vítima tivesse pedido. A vítima nunca pediu, e o atacante nunca soube a senha nem leu o cookie.
 
-## 1. Context
+## 1. Contexto
 
 O `POST /email` é uma **request de mudança-de-estado** — uma que altera algo no servidor (aqui, o e-mail de recuperação da conta). O servidor a autoriza checando uma coisa: existe um **cookie de sessão** válido? Isto é **CSRF (Cross-Site Request Forgery)**: um atacante faz o browser da vítima disparar uma request de mudança-de-estado num site onde ela está logada, pegando carona na sessão dela. Dois termos nomeiam o cenário. **Cross-site** quer dizer que a request parte de um *site diferente* do alvo (um host registrável diferente — aqui `127.0.0.2` versus o `127.0.0.1` do alvo). A **Same-Origin Policy (SOP)** é a regra do browser que deixa uma origem *enviar* uma request pra outra mas proíbe *ler* a resposta — por isso o CSRF é um ataque cego, fire-and-forget: o atacante dispara a ação mas nunca vê o resultado.
 
@@ -16,7 +16,7 @@ Três serviços, e nenhum fala com o outro — o browser da vítima faz toda req
 
 Como o ato que define o CSRF é o browser anexar o cookie sozinho, o browser é onde você explora; o Burp é uma lente de apoio que mostra a request forjada na rede.
 
-## 2. Spot the bug
+## 2. Ache o bug
 
 Abra [`vulnerable/app.py`](./vulnerable/app.py). O bug inteiro é a checagem de autorização no `POST /email`:
 
@@ -39,7 +39,7 @@ Set-Cookie: session_vuln=...; Secure; HttpOnly; Path=/; SameSite=None
 
 `SameSite=None` é o sinal verde pro browser anexar este cookie em requests cross-site.
 
-## 3. Exploitation (no browser)
+## 3. Exploração (no browser)
 
 O ato que define o ataque — o browser anexar o cookie da vítima numa request cross-site — só acontece num browser, então é aqui que você explora. Passe o browser pelo proxy do Burp pra capturar o tráfego pra Seção 4.
 
@@ -79,7 +79,7 @@ O e-mail de recuperação agora é o do atacante. **Account takeover:** quem con
 
 Tudo aqui é benigno e local: uma conta fake, um endereço `@evil.example` (um TLD reservado), tudo em loopback, nada destrutivo.
 
-## 4. What Burp shows (e por que o `curl` não)
+## 4. O que o Burp mostra (e por que o `curl` não)
 
 O CSRF é disparado do browser, mas o Burp prova a mecânica. Em **Proxy → HTTP history**, ache o `POST /email` forjado que a página do atacante disparou:
 
@@ -107,7 +107,7 @@ $ curl -X POST -H "Cookie: session_vuln=<cole>" -d "email=x@evil.example" \
 
 A segunda chamada funciona, mas não é CSRF: *você* colou um cookie que já tinha. Não há vítima, não há outro site, nada foi enganado. O CSRF é justo a parte que o `curl` não consegue fazer — fazer o browser de uma *vítima* anexar o cookie *dela* a uma request que o *atacante* disparou de *outra origem*. Isso só acontece num browser, e é por isso que o exploit é browser-driven e o Burp só observa.
 
-## 5. What the vuln is NOT
+## 5. O que a vuln NÃO é
 
 O exploit é uma request de aparência legítima, então isole o que de fato deu errado:
 
@@ -117,11 +117,11 @@ O exploit é uma request de aparência legítima, então isole o que de fato deu
 
 O que **é**: o servidor autoriza uma ação de mudança-de-estado só pelo cookie — *quem* você é — sem checar *que você quis*. O fix exige uma prova de intenção que o atacante não consegue suprir.
 
-## 6. Impact
+## 6. Impacto
 
 **Account takeover via uma mudança-de-estado forçada.** O `POST` forjado troca o e-mail de recuperação da conta por um que o atacante controla; um "esqueci a senha" seguinte manda o reset pro atacante. Mais amplamente, qualquer ação de mudança-de-estado guardada só pelo cookie de sessão — trocar e-mail, trocar senha, transferir dinheiro, adicionar admin — pode ser disparada de uma página que a vítima só visita. Sem overclaim: CSRF é sobre *ações que a vítima não pediu*, não roubo de dado — a Same-Origin Policy cega o atacante pra resposta — e roda no browser da vítima, não no servidor.
 
-## 7. Why the fix works
+## 7. Por que o fix funciona
 
 Aponte a página do atacante pro alvo fixed: abra `http://127.0.0.2:8080/attack-fixed` (o form dela posta pra `127.0.0.1:8123/email`) com a vítima logada em `127.0.0.1:8123`. A request forjada retorna:
 

--- a/atoms/A02-cryptographic-failures/jwt-none-alg/WALKTHROUGH.pt-BR.md
+++ b/atoms/A02-cryptographic-failures/jwt-none-alg/WALKTHROUGH.pt-BR.md
@@ -9,7 +9,7 @@ A app é um login mínimo baseado em token. Você visita `/`, o servidor te entr
 
 Os dois endpoints esperam o header padrão `Authorization: Bearer <jwt>`. Seu objetivo, como `alice` (usuário comum), é ler `/admin` sem ter a chave de assinatura de um admin.
 
-## 2. Anatomy of a JWT
+## 2. Anatomia de um JWT
 
 Você não consegue explorar o que não consegue ler. Antes do primeiro request, internalize o layout do JWT — os próximos passos vão editar cada peça em sequência.
 

--- a/atoms/A03-injection/sqli-blind-time/WALKTHROUGH.pt-BR.md
+++ b/atoms/A03-injection/sqli-blind-time/WALKTHROUGH.pt-BR.md
@@ -62,7 +62,7 @@ A primitiva usada aqui é um recursive CTE pequeno, cross-joined consigo mesmo:
 
 O CTE constrói uma tabelinha `t` de `K = 18000` linhas, e então `count(*) FROM t a, t b` conta os `K²` ≈ 324 milhões de pares do cross join. Contar esses pares é trabalho puro de CPU e leva alguns segundos, mas a memória fica estável: a única coisa materializada é a tabela de `K` linhas (dezenas de KB), nunca os `K²` pares. `K = 18000` foi calibrado contra o container deste lab (SQLite 3.46.1) pra cair em torno de **3–4 segundos** por execução; o número exato é CPU-dependente, então se os seus delays voltarem bem mais curtos ou longos, ajuste `K` (o tempo cresce com `K²`, então mudanças pequenas movem bastante). O que importa nunca é o número absoluto — é o *contraste* entre segundos e milissegundos. Você vai ver esse bloco exato, por extenso, dentro de todo payload abaixo — ele nunca é abreviado.
 
-### Step 1 — Provar a injeção *e* descobrir o único canal
+### Passo 1 — Provar a injeção *e* descobrir o único canal
 
 Não há bloco de debug, nem erro, nem linha pra ler — então o primeiro probe tem que ser o próprio delay. Injete a expressão de forma incondicional e olhe o relógio.
 
@@ -90,7 +90,7 @@ Esse é o coração conceitual do átomo. No `sqli-blind-boolean`, *confirmar a 
 
 **O que isso NÃO é:** uma única resposta lenta não prova nada sozinha — poderia ser jitter de rede ou servidor ocupado. A prova é *repetibilidade e controle*. Reenvie esse payload duas ou três vezes: ele trava toda vez. Depois mande o benigno `username=alice&password=wonderland` de novo: instantâneo. O sinal de time-based blind não é "a resposta foi lenta", é "eu consigo deixar a resposta lenta sob demanda, e rápida de novo sob demanda". O Step 2 transforma esse controle num oráculo de sim/não.
 
-### Step 2 — Tornar o delay condicional (o oráculo temporal)
+### Passo 2 — Tornar o delay condicional (o oráculo temporal)
 
 Envolva o delay num `CASE` pra ele só disparar quando uma condição é verdadeira. O `CASE` do SQLite avalia só o ramo cujo `WHEN` casou, então a expressão cara no `THEN` só roda numa condição verdadeira.
 
@@ -115,7 +115,7 @@ Você agora tem os dois estados do oráculo, lidos no relógio em vez de na pág
 
 Qualquer pergunta de sim/não que você consiga expressar em SQL pode agora ser respondida colocando ela no slot `WHEN (...)` e cronometrando a resposta. É o gêmeo temporal do Step 2/3 do `sqli-blind-boolean`: a *pergunta* fica exatamente no mesmo lugar; só o que *responde* mudou — latency, não texto.
 
-### Step 3 — Extrair o comprimento da senha por timing
+### Passo 3 — Extrair o comprimento da senha por timing
 
 Troque a condição placeholder por uma sobre dado real: o comprimento da senha da alice é igual a `N`? Comece com um probe concreto que pergunta se o comprimento é 10.
 
@@ -139,7 +139,7 @@ Itere o número no mesmo lugar (no Repeater, edite só o `10`) e cronometre cada
 
 Conclusão: a senha da alice tem **10 caracteres**. Você descobriu um fato sobre um dado que não consegue ler, puramente pela latency da resposta. Fazer dois ou três probes na mão é o suficiente pra sentir o ritmo antes do próximo passo aumentar a escala.
 
-### Step 4 — Extrair um caractere por timing
+### Passo 4 — Extrair um caractere por timing
 
 Pergunta mais fina: o caractere na posição `P` é igual ao candidato `C`? `SUBSTR(password, P, 1)` extrai um caractere; a comparação transforma ele no único bit que o cronômetro revela. Comece testando o primeiro caractere (`P = 1`) contra o candidato `w`.
 
@@ -159,7 +159,7 @@ Na mão, no primeiro caractere: como enviado acima, o candidato `'w'` faz a resp
 
 Os dois argumentos numéricos do `SUBSTR` têm papéis distintos, e a distinção importa pro próximo passo. O primeiro (`1`) é a *posição* — qual caractere ler, o que você varia pra varrer a senha inteira. O segundo (`1`) é o *tamanho* — quantos caracteres ler, sempre 1.
 
-### Step 5 — Automatizar com Burp Intruder, lendo a coluna de latency
+### Passo 5 — Automatizar com Burp Intruder, lendo a coluna de latency
 
 É aqui que você reusa o `sqli-blind-boolean` quase verbatim. A configuração do Intruder é **idêntica** à daquele átomo — mesmo attack type, mesmos dois payload sets — com exatamente **uma** diferença: qual coluna você lê como oráculo. Lá, era um checkbox do Grep — Match. Aqui, toda response body é byte-a-byte idêntica, então não há string pra casar; o oráculo é a **coluna de response time**.
 

--- a/atoms/A03-injection/xss-stored/WALKTHROUGH.pt-BR.md
+++ b/atoms/A03-injection/xss-stored/WALKTHROUGH.pt-BR.md
@@ -43,7 +43,7 @@ Mesmas lições do `xss-reflected`, afiadas:
 
 Configure o Burp Proxy, aponte o browser pra ele e visite <http://127.0.0.1:8008/>. Submeta um comentário descartável pelo form pra o Burp capturar um `POST /comment` em **Proxy → HTTP history**; clique com o direito nele e escolha **Send to Repeater**. Esse POST é o instrumento do atacante — você edita o corpo dele e reenvia pra plantar payloads com controle total sobre os bytes exatos.
 
-### Uma nota sobre encoding do corpo
+### Uma nota sobre encoding do body
 
 O corpo do `POST /comment` é `application/x-www-form-urlencoded`: `author=<...>&body=<...>`. Ao editar à mão no Repeater, caracteres que são estruturais nesse formato precisam de encode dentro de um valor:
 

--- a/atoms/A05-security-misconfiguration/xxe-basic/WALKTHROUGH.pt-BR.md
+++ b/atoms/A05-security-misconfiguration/xxe-basic/WALKTHROUGH.pt-BR.md
@@ -39,7 +39,7 @@ Content-Length: 121
 xml=%3Ccontact%3E%0A++%3Cname%3EAda+Lovelace%3C%2Fname%3E%0A++%3Cemail%3Eada%40example.com%3C%2Femail%3E%0A%3C%2Fcontact%3E
 ```
 
-### Uma nota sobre encoding do corpo
+### Uma nota sobre encoding do body
 
 O corpo é `application/x-www-form-urlencoded`, e esse formato tem uma armadilha que pega todo mundo uma vez: **`&` separa campos.** Seu payload de XXE usa `&x;` pra referenciar a entity — se você colar cru, o `&` inicia um novo campo de form e o servidor nunca vê a sua referência de entity. Então o **valor** inteiro de `xml=` precisa ser URL-encoded: `<` → `%3C`, `>` → `%3E`, `"` → `%22`, e crucialmente `&` → `%26`.
 

--- a/atoms/A08-data-integrity-failures/prototype-pollution/WALKTHROUGH.pt-BR.md
+++ b/atoms/A08-data-integrity-failures/prototype-pollution/WALKTHROUGH.pt-BR.md
@@ -2,7 +2,7 @@
 
 A app guarda as suas preferências: você manda um corpo JSON com campos de config pro `POST /settings`, e ela faz um *deep-merge* deles nos settings atuais — descendo recursivamente em objetos aninhados. O merge é uma função recursiva escrita à mão, e ela desce por *quaisquer* chaves que o seu JSON carregue. Uma dessas chaves é especial: `__proto__`. Mande-a e o merge, em vez de escrever num campo do objeto de settings, escreve no `Object.prototype` — o pai compartilhado por todo objeto do processo Node inteiro. A prova está num segundo endpoint que não tem nada a ver com settings: o `GET /me` cria um objeto de usuário novo e vazio e checa `if (user.isAdmin)`. Depois do ataque, esse objeto fresco — que você nunca tocou — responde admin. Tudo aqui é feito no Burp (ou `curl`); não há passo de browser, porque o JavaScript roda no **servidor** e o efeito é visível na resposta.
 
-## 1. Context
+## 1. Contexto
 
 A app `vulnerable` está em `127.0.0.1:8026` e a `fixed` em `127.0.0.1:8126`; não há banco nem segundo serviço — os settings vivem num objeto JavaScript dentro do processo Node. Dois endpoints:
 
@@ -20,7 +20,7 @@ Isto é **prototype pollution**. Como este é o primeiro átomo JavaScript do re
 
 Isto é **A08 — Software and Data Integrity Failures**; o CWE dele (Common Weakness Enumeration — o catálogo padrão de classes de fraqueza) é **CWE-1321**, "Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')". A exploração é feita inteiramente no Burp; `curl` é o equivalente — não há trilha browser (este átomo é API-only, e o JavaScript roda server-side).
 
-## 2. Spot the bug
+## 2. Ache o bug
 
 Abra [`vulnerable/app.js`](./vulnerable/app.js). O merge é a história inteira:
 
@@ -44,7 +44,7 @@ O loop percorre `Object.keys(source)` e, pra cada chave cujo valor é um objeto,
 
 Uma sutileza explica por que o corpo JSON é a superfície de ataque. Se você escrevesse o object-literal `{ __proto__: ... }` no código, `__proto__` seria um *setter* especial (ele seta o prototype do literal) e **não** viraria uma chave normal — um loop de merge nunca a veria. Mas o dado do atacante não é um literal; é texto que passa por `JSON.parse`, e o parser faz `__proto__` virar uma **chave própria comum**. Então `Object.keys(source)` a entrega, e o loop desce. O fix (foreshadow): fazer o merge **recusar** as chaves que alcançam um prototype, em vez de descer por elas.
 
-## 3. Exploitation via Burp Suite
+## 3. Exploração via Burp Suite
 
 Aponte o Burp pra API vulnerable em `127.0.0.1:8026` e trabalhe no Repeater. Cada request abaixo é um bloco que você cola no Repeater; as mesmas requests rodam no `curl`. (Os blocos de `POST /settings` carregam `Content-Type: application/json`; este servidor escrito à mão chama `JSON.parse` no corpo independente do header, mas mandá-lo é correto e casa com um cliente real.)
 
@@ -88,7 +88,7 @@ curl -i http://127.0.0.1:8026/settings -H 'Content-Type: application/json' \
 
 A feature funciona: o merge escreve `theme` e deixa `notifications` em paz. O `GET /me` continua `{"admin":false}` — um merge benigno não muda nada de privilégio. Daqui pra frente, só uma coisa muda — a chave de topo do JSON vira `__proto__`.
 
-### Step 1 — Poluir o prototype (o ataque)
+### Passo 1 — Poluir o prototype (o ataque)
 
 Mande um corpo cuja chave de topo é `__proto__`, carregando `isAdmin: true`:
 
@@ -113,7 +113,7 @@ curl -i http://127.0.0.1:8026/settings -H 'Content-Type: application/json' \
   -d '{"__proto__":{"isAdmin":true}}'
 ```
 
-### Step 2 — Confirmar a contaminação global
+### Passo 2 — Confirmar a contaminação global
 
 Volte pro endpoint do usuário fresco — o que nunca mencionou settings:
 
@@ -132,7 +132,7 @@ Essa é a prototype pollution. O `GET /me` cria um objeto **novo e vazio** e lê
 
 > A poluição é global ao processo e agora fica até o container reiniciar, então rode o baseline **antes** do ataque — como acima — pra ver a virada `false` → `true` limpa. Pra resetar, `./atom down prototype-pollution` e depois `./atom up prototype-pollution` (ou `docker compose restart vulnerable`).
 
-## 4. What the vuln is NOT
+## 4. O que a vuln NÃO é
 
 O exploit é uma chave num corpo JSON, então é fácil tirar a lição errada. Isole a causa real:
 
@@ -144,13 +144,13 @@ O exploit é uma chave num corpo JSON, então é fácil tirar a lição errada. 
 
 A única coisa que **é**: o merge desce por `__proto__` e muta o `Object.prototype` compartilhado, então todo objeto — inclusive o `{}` fresco do `GET /me` — herda o campo plantado. O fix é fazer o merge **recusar** as chaves que alcançam um prototype (`__proto__`, `constructor`, `prototype`).
 
-## 5. Impact
+## 5. Impacto
 
 **Contaminação global do `Object.prototype`:** qualquer código que leia uma propriedade herdada assumindo que ela é ausente — `if (user.isAdmin)` — é subvertido. O exemplo deste lab é um bypass de autorização: um objeto de usuário default, sem privilégio, responde admin. A poluição **persiste** no processo até um restart, e afeta objetos criados *depois* do ataque, longe do ponto de injeção.
 
 Esse é o teto honesto deste átomo. **Não é RCE por padrão.** Prototype pollution *pode* escalar pra remote code execution no mundo real, mas só com *gadgets* específicos — uma cadeia onde uma propriedade herdada envenenada flui pra um sink perigoso de alguma lib ou do runtime (um template engine, `child_process`, `require`). Isso depende do ecossistema em volta e não é uma propriedade da falha isolada; seria um segundo mecanismo, então fica fora de escopo aqui. O teto difere do `deserialization-pickle`, o outro átomo A08 do repo, que chega a RCE por causa própria. O valor desta classe está em quão *silenciosa e global* ela é: uma chave num corpo JSON contamina todo objeto do processo, e o dano aparece onde algum código lê uma propriedade herdada que assumia ausente.
 
-## 6. Why the fix works
+## 6. Por que o fix funciona
 
 Rode a cadeia contra a API fixed na porta **8126** (veja o [`DIFF.pt-BR.md`](./DIFF.pt-BR.md) pra a mudança). Ela começa limpa — `GET /me` → `{"admin":false}`. Agora mande o **mesmo payload de ataque**:
 

--- a/atoms/A10-ssrf/ssrf-cloud-metadata/WALKTHROUGH.pt-BR.md
+++ b/atoms/A10-ssrf/ssrf-cloud-metadata/WALKTHROUGH.pt-BR.md
@@ -4,13 +4,13 @@ Você vai fazer o servidor buscar a única URL que existe em toda instância de 
 
 Há um único ator neste átomo: você, o pentester. A trilha principal é o Burp Repeater.
 
-## 1. Context
+## 1. Contexto
 
 A app é uma ferramenta "Fetch from URL". Em `/` há um form com um campo de URL; submetê-lo envia `POST /fetch`, e o servidor busca aquela URL com a biblioteca `requests` e renderiza o corpo da resposta de volta pra você dentro de um bloco `<pre>`. O valor padrão é `https://api.github.com/zen`, um endpoint público real que devolve uma linha curta de texto — bom pra confirmar que a feature funciona antes de deixar a URL interessante.
 
 Isto é **A10 — Server-Side Request Forgery (SSRF)**, apontado para o cloud metadata endpoint.
 
-## 2. About this lab's environment
+## 2. Sobre o ambiente deste lab
 
 Três containers sobem juntos (veja [`docker-compose.yml`](./docker-compose.yml)):
 
@@ -21,7 +21,7 @@ Num engagement real, `169.254.169.254` é o metadata service da própria instân
 
 `vulnerable` e `fixed` compartilham **uma** rede Docker com o `metadata-mock` aqui (o mock está fixado num IP fixo, que só pode viver numa subnet). As duas apps alcançam o mock no nível de rede — que é o que torna a recusa posterior da app fixed o seu **código de aplicação**, não a rede.
 
-## 3. Spot the bug
+## 3. Ache o bug
 
 Abra [`vulnerable/app.py`](./vulnerable/app.py). A view `/fetch` é curta:
 
@@ -46,7 +46,7 @@ O valor de form `url` flui direto pra `requests.get(url, ...)`. Não há parsing
 
 Configure o Burp Proxy e aponte seu browser pra ele. Visite <http://127.0.0.1:8017/>, submeta o form uma vez com a URL padrão pra capturar o tráfego, depois clique com o botão direito no request `POST /fetch` em **Proxy → HTTP history** e escolha **Send to Repeater**. O corpo é `url=<sua URL>`; quando você editar, o Burp recalcula o `Content-Length` pra você. (`:` e `/` sem encoding dentro do valor de form são OK — o Flask decodifica o valor como está — então você pode digitar a URL de forma legível.)
 
-### Step 1 — Confirme que a feature funciona
+### Passo 1 — Confirme que a feature funciona
 
 Request no Repeater:
 
@@ -60,7 +60,7 @@ url=https://api.github.com/zen
 
 Resposta: status `200`; o bloco `<pre>` contém uma única linha curta, ex. `Anything added dilutes everything else.` (a frase varia a cada request). Este é o seu baseline — o uso legítimo da feature. Note o mecanismo silencioso: **o Burp mostra a resposta como se o seu browser tivesse buscado `api.github.com`, mas não foi. Foi o servidor, e ele repassou o corpo de volta pra você.** (Este passo precisa de egress de internet; se o lab estiver offline você verá um `Request error` — pule pro Step 2, que mira o mock interno e não precisa de egress.)
 
-### Step 2 — Recon: peça o nome do role ao metadata endpoint
+### Passo 2 — Recon: peça o nome do role ao metadata endpoint
 
 Troque o corpo pelo diretório de credenciais do metadata endpoint:
 
@@ -80,7 +80,7 @@ app-instance-role
 
 Esse é o nome do role IAM anexado à instância. O metadata service te disse, sem autenticação, sobre HTTP puro, através da app. `169.254.169.254` é um host que sua máquina não alcança de forma útil, mas o container da app está um hop mais perto — exatamente a assimetria que o SSRF explora.
 
-### Step 3 — Loot: leia as credenciais do role
+### Passo 3 — Loot: leia as credenciais do role
 
 Anexe o nome do role ao path:
 


### PR DESCRIPTION
## What changed

- Translated 28 section headers (`##`/`###`/`####`) that had been left in English across 6 PT-BR docs — the `jwt-none-alg`, `sqli-blind-time`, `ssrf-cloud-metadata`, `csrf-basic`, and `prototype-pollution` walkthroughs, plus the `bola-rest` DIFF. Only the structural text was translated; technical terms (payload, delay, prototype, role, Recon/Loot, etc.) stay in English.
- Standardized the HTTP term `body` over `corpo` in 2 section headers (`xxe-basic` and `xss-stored` walkthroughs).
- CLAUDE.md: §7 now states that section headers are translated in every PT doc (the README h1 is the only exception); §11 gains a checklist item catching an untranslated header (byte-identical to the EN pair); §14 revision date updated.

## How it was verified

Read-only audit of all 79 EN↔PT doc pairs. After the change, zero PT section headers are byte-identical to their EN counterpart (h1 excluded). No EN file was touched.
