### PR TITLE
docs(changelog): fix and backfill version compare links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,9 @@ First public release — MVP Pentester (Phase 1 of the ROADMAP).
 - Established bilingual documentation requirement: every atom ships EN + PT-BR versions of `README.md`, `WALKTHROUGH.md`, and `DIFF.md`, kept in sync within the same commit.
 - Established Burp Suite as the primary exploration path in every walkthrough; UI is context only.
 
-[Unreleased]: https://github.com/doretox/atomicvulns/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/doretox/atomicvulns/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/doretox/atomicvulns/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/doretox/atomicvulns/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/doretox/atomicvulns/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/doretox/atomicvulns/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/doretox/atomicvulns/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,6 +437,7 @@ Todo átomo passa por este checklist manual antes de ir pro `main`:
 - [ ] Nenhum header de seção (`##`/`###`/`####`) do arquivo PT é byte-idêntico ao par EN (o h1 do README é a única exceção).
 - [ ] Sem credenciais reais, sem dados sensíveis de clientes.
 - [ ] Átomo marcado como concluído em `ROADMAP.md`.
+- [ ] O rodapé de links do `CHANGELOG.md` tem uma linha de compare para cada versão, e o `[Unreleased]` aponta da última release cortada até HEAD.
 
 ---
 


### PR DESCRIPTION
## What changed

- `[Unreleased]` re-points from v0.3.0 to v0.5.0.
- Backfills the v0.4.0 and v0.5.0 compare links.
- CLAUDE.md §11 gains a checklist item requiring the CHANGELOG compare links stay current.

No release, no tag.
